### PR TITLE
Add ClusterPolicy controller and automatically exclude chart-operator from custom policies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ workflows:
           app_catalog: "giantswarm-catalog"
           app_catalog_test: "giantswarm-test-catalog"
           chart: "kyverno-policy-operator"
+          requires:
+            - push-kyverno-policy-operator-to-docker
           # Trigger job on git tag.
           filters:
             tags:
@@ -72,11 +74,13 @@ workflows:
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "kyverno-policy-operator"
+          requires:
+            - push-kyverno-policy-operator-to-docker
           # Trigger job on git tag.
           filters:
             tags:
               only: /^v.*/
-      
+
       # Push to collections
       - architect/push-to-app-collection:
           name: aws-app-collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `ClusterPolicy` controller to automatically exclude `chart-operator` ServiceAccount from custom policies.
+
 ## [0.0.3] - 2023-10-24
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/kyverno/kyverno v1.10.3
+	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
 	sigs.k8s.io/controller-runtime v0.15.1
@@ -264,7 +265,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a // indirect
-	k8s.io/api v0.28.2 // indirect
 	k8s.io/apiextensions-apiserver v0.28.2 // indirect
 	k8s.io/component-base v0.28.2 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect

--- a/helm/kyverno-policy-operator/templates/deployment.yaml
+++ b/helm/kyverno-policy-operator/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           - --destination-namespace={{ .Values.policyOperator.destinationNamespace }}
         {{- end }}
         {{- if .Values.policyOperator.chartOperatorExcemptedKinds }}
-          - --target-labels={{ .Values.policyOperator.chartOperatorExcemptedKinds | join "," }}
+          - --chart-operator-excempted-kinds={{ .Values.policyOperator.chartOperatorExcemptedKinds | join "," }}
         {{- end }}
           - --background-mode={{ .Values.policyOperator.exceptionBackgroundMode }}
         ports:

--- a/helm/kyverno-policy-operator/templates/deployment.yaml
+++ b/helm/kyverno-policy-operator/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
         {{- if .Values.policyOperator.destinationNamespace }}
           - --destination-namespace={{ .Values.policyOperator.destinationNamespace }}
         {{- end }}
+        {{- if .Values.policyOperator.chartOperatorExcemptedKinds }}
+          - --target-labels={{ .Values.policyOperator.chartOperatorExcemptedKinds | join "," }}
+        {{- end }}
           - --background-mode={{ .Values.policyOperator.exceptionBackgroundMode }}
         ports:
         - containerPort: 8080

--- a/helm/kyverno-policy-operator/values.yaml
+++ b/helm/kyverno-policy-operator/values.yaml
@@ -67,3 +67,6 @@ policyOperator:
   destinationNamespace: "policy-exceptions"
   # Apply the generated PolicyExceptions also in Kyverno background scans. Changes audit results from fail to skip.
   exceptionBackgroundMode: true
+  chartOperatorExcemptedKinds:
+    - PolicyException
+    - Namespace

--- a/internal/controller/clusterpolicy_controller.go
+++ b/internal/controller/clusterpolicy_controller.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/go-logr/logr"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ClusterPolicyReconciler reconciles a ClusterPolicy object
+type ClusterPolicyReconciler struct {
+	client.Client
+	Scheme         *runtime.Scheme
+	Log            logr.Logger
+	ExceptionList  map[string]kyvernov1.ClusterPolicy
+	ExceptionKinds []string
+}
+
+//+kubebuilder:rbac:groups=kyverno.io,resources=clusterpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kyverno.io,resources=clusterpolicies/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kyverno.io,resources=clusterpolicies/finalizers,verbs=update
+
+func (r *ClusterPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = log.FromContext(ctx)
+	_ = r.Log.WithValues("clusterpolicy", req.NamespacedName)
+
+	var clusterPolicy kyvernov1.ClusterPolicy
+
+	if err := r.Get(ctx, req.NamespacedName, &clusterPolicy); err != nil {
+		// Error fetching the report
+
+		// Check if the ClusterPolicy was deleted
+		if apierrors.IsNotFound(err) {
+			// Ignore
+			return ctrl.Result{}, nil
+		}
+
+		log.Log.Error(err, "unable to fetch ClusterPolicy")
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the Policy has validate rules
+	if !clusterPolicy.HasValidate() {
+		return ctrl.Result{}, nil
+	}
+
+	// Inspect the Rules
+	for _, rule := range clusterPolicy.Spec.Rules {
+		// Check if the rule has a validate section
+		if rule.HasValidate() {
+			for _, kind := range rule.MatchResources.GetKinds() {
+				// Check for Namespace validation
+				for _, destinationKind := range r.ExceptionKinds {
+					if kind == destinationKind {
+						// Append exception to PolicyException
+						if _, exists := r.ExceptionList[clusterPolicy.Name]; !exists {
+							r.ExceptionList[clusterPolicy.Name] = clusterPolicy
+
+							// Template Kyverno Polex
+							policyException := kyvernov2alpha1.PolicyException{}
+
+							// Set namespace
+							policyException.Namespace = "giantswarm"
+
+							// Set name
+							policyException.Name = "chart-operator-generated-sa-bypass"
+
+							// Set labels
+							policyException.Labels = make(map[string]string)
+							policyException.Labels["app.kubernetes.io/managed-by"] = "kyverno-policy-operator"
+
+							// Set Background behaviour to false since this Polex is using Subjects
+							background := false
+							policyException.Spec.Background = &background
+
+							// Set Spec.Match.All
+							policyException.Spec.Match.All = templateResourceFilters(r.ExceptionKinds)
+
+							// Set .Spec.Exceptions
+							newExceptions := translatePoliciesToExceptions(r.ExceptionList)
+							policyException.Spec.Exceptions = newExceptions
+
+							// Patch PolicyException Kinds
+							gvks, unversioned, err := r.Scheme.ObjectKinds(&policyException)
+							if err != nil {
+								return ctrl.Result{}, err
+							}
+							if !unversioned && len(gvks) == 1 {
+								policyException.SetGroupVersionKind(gvks[0])
+							}
+
+							if err := r.CreateOrUpdate(ctx, &policyException); err != nil {
+								log.Log.Error(err, "Error creating PolicyException")
+							} else {
+								log.Log.Info(fmt.Sprintf("ClusterPolicy %s triggered a PolicyException update: %s", clusterPolicy.Name, client.ObjectKeyFromObject(&policyException)))
+							}
+
+							return ctrl.Result{}, nil
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// CreateOrUpdate attempts first to patch the object given but if an IsNotFound error
+// is returned it instead creates the resource.
+func (r *ClusterPolicyReconciler) CreateOrUpdate(ctx context.Context, obj client.Object) error {
+	existingObj := unstructured.Unstructured{}
+	existingObj.SetGroupVersionKind(obj.GetObjectKind().GroupVersionKind())
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(obj), &existingObj)
+	switch {
+	case err == nil:
+		// Update:
+		obj.SetResourceVersion(existingObj.GetResourceVersion())
+		obj.SetUID(existingObj.GetUID())
+		return r.Patch(ctx, obj, client.MergeFrom(existingObj.DeepCopy()))
+	case errors.IsNotFound(err):
+		// Create:
+		return r.Create(ctx, obj)
+	default:
+		return err
+	}
+}
+
+func templateResourceFilters(kinds []string) kyvernov1.ResourceFilters {
+	var resourceFilters kyvernov1.ResourceFilters
+	trasnlatedResourceFilter := kyvernov1.ResourceFilter{
+		UserInfo: kyvernov1.UserInfo{
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "chart-operator",
+				Namespace: "giantswarm",
+			}},
+		},
+		ResourceDescription: kyvernov1.ResourceDescription{
+			Kinds:      kinds,
+			Operations: []kyvernov1.AdmissionOperation{"CREATE", "UPDATE"},
+		},
+	}
+	resourceFilters = append(resourceFilters, trasnlatedResourceFilter)
+
+	return resourceFilters
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClusterPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kyvernov1.ClusterPolicy{}).
+		Complete(r)
+}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,9 +1,10 @@
 package controller
 
 import (
-	giantswarmPolicy "github.com/giantswarm/kyverno-policy-operator/api/v1alpha1"
 	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+
+	giantswarmPolicy "github.com/giantswarm/kyverno-policy-operator/api/v1alpha1"
 )
 
 // translateTargetsToResourceFilters takes a Giant Swarm PolicyException and creates the necessary Kyverno ResourceFilters

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	giantswarmPolicy "github.com/giantswarm/kyverno-policy-operator/api/v1alpha1"
+	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
+	kyvernov2alpha1 "github.com/kyverno/kyverno/api/kyverno/v2alpha1"
+)
+
+// translateTargetsToResourceFilters takes a Giant Swarm PolicyException and creates the necessary Kyverno ResourceFilters
+func translateTargetsToResourceFilters(polex giantswarmPolicy.PolicyException) kyvernov1.ResourceFilters {
+	resourceFilters := kyvernov1.ResourceFilters{}
+	for _, target := range polex.Spec.Targets {
+		trasnlatedResourceFilter := kyvernov1.ResourceFilter{
+			ResourceDescription: kyvernov1.ResourceDescription{
+				Namespaces: target.Namespaces,
+				Names:      target.Names,
+				Kinds:      generateExceptionKinds(target.Kind),
+			},
+		}
+		resourceFilters = append(resourceFilters, trasnlatedResourceFilter)
+	}
+	return resourceFilters
+}
+
+// translatePoliciesToExceptions takes a Kyverno ClusterPolicy array and transforms it into a Kyverno Exception array
+func translatePoliciesToExceptions(policies map[string]kyvernov1.ClusterPolicy) []kyvernov2alpha1.Exception {
+	var exceptionArray []kyvernov2alpha1.Exception
+	for policyName, kyvernoPolicy := range policies {
+		kyvernoException := kyvernov2alpha1.Exception{
+			PolicyName: policyName,
+			RuleNames:  generatePolicyRules(kyvernoPolicy),
+		}
+		exceptionArray = append(exceptionArray, kyvernoException)
+	}
+
+	return exceptionArray
+}
+
+// generatePolicyRules takes a Kyverno Policy name and generates a list of rules owned by that policy
+func generatePolicyRules(kyvernoPolicy kyvernov1.ClusterPolicy) []string {
+	var rulesArray []string
+	for _, rule := range kyvernoPolicy.Spec.Rules {
+		rulesArray = append(rulesArray, rule.Name)
+	}
+	for _, autogenRule := range kyvernoPolicy.Status.Autogen.Rules {
+		rulesArray = append(rulesArray, autogenRule.Name)
+	}
+
+	return rulesArray
+}
+
+// unorderedEqual takes two Kyverno Exception arrays and checks if they are equal even if they are not ordered the same
+func unorderedEqual(got, want []kyvernov2alpha1.Exception) bool {
+	// Check Length size first
+	if len(got) != len(want) {
+		return false
+	}
+	// Create an exceptions map with the new desired Exceptions
+	exceptionMap := make(map[string][]string)
+	for _, exception := range want {
+		exceptionMap[exception.PolicyName] = exception.RuleNames
+	}
+	for _, exception := range got {
+		// Check if the Policy Name is still present in the new Exceptions
+		if _, exists := exceptionMap[exception.PolicyName]; !exists {
+			// The Policy is not present in the new array
+			// Arrays are not equals, exit
+			return false
+		} else {
+			// Check if the same RuleNames are still present in the new Exceptions
+			for _, oldRule := range exception.RuleNames {
+				found := false
+				// Check against every rule, exit if found
+				for _, newRule := range exceptionMap[exception.PolicyName] {
+					if newRule == oldRule {
+						// Found, break for
+						found = true
+						break
+					}
+				}
+				if !found {
+					// The arrays are not equals, exit
+					return false
+				}
+				// Rules are equals, continue
+			}
+		}
+	}
+	// Arrays are equals
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -87,9 +87,9 @@ func main() {
 		"A comma-separated list of kinds to be excluded from custom ClusterPolicies. This lets the chart-operator ServiceAccount to create protected objects.",
 		func(input string) error {
 			items := strings.Split(input, ",")
-			for _, kind := range items {
-				chartOperatorExcemptedKinds = append(chartOperatorExcemptedKinds, kind)
-			}
+
+			chartOperatorExcemptedKinds = append(chartOperatorExcemptedKinds, items...)
+
 			return nil
 		})
 	opts.BindFlags(flag.CommandLine)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -68,6 +69,7 @@ func main() {
 	var probeAddr string
 	var destinationNamespace string
 	var backgroundMode bool
+	var chartOperatorExcemptedKinds []string
 	// Flags
 	flag.StringVar(&destinationNamespace, "destination-namespace", "", "The namespace where the Kyverno PolicyExceptions will be created. Defaults to GS PolicyException namespace.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -81,6 +83,15 @@ func main() {
 	flag.BoolVar(&backgroundMode, "background-mode", false,
 		"Enable PolicyException background mode. If true, failing resources have a status of 'skip' in reports, instead of 'fail'. Defaults to false.",
 	)
+	flag.Func("chart-operator-excempted-kinds",
+		"A comma-separated list of kinds to be excluded from custom ClusterPolicies. This lets the chart-operator ServiceAccount to create protected objects.",
+		func(input string) error {
+			items := strings.Split(input, ",")
+			for _, kind := range items {
+				chartOperatorExcemptedKinds = append(chartOperatorExcemptedKinds, kind)
+			}
+			return nil
+		})
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
@@ -118,6 +129,18 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PolicyException")
 		os.Exit(1)
+	}
+
+	if len(chartOperatorExcemptedKinds) != 0 {
+		if err = (&controller.ClusterPolicyReconciler{
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			ExceptionList:  make(map[string]kyvernov1.ClusterPolicy),
+			ExceptionKinds: chartOperatorExcemptedKinds,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "PolicyException")
+			os.Exit(1)
+		}
 	}
 	//+kubebuilder:scaffold:builder
 


### PR DESCRIPTION
This PR adds the functionality needed to exclude `chart-operator` ServiceAccount from custom policies automatically.

The new `clusterpolicy` controller will check for ClusterPolicy changes and create a custom PolicyException based on the list of `Kinds` defined in the `chartOperatorExcemptedKinds` value.

If no `Kinds` are defined, the controller does not run.