### PR TITLE
Don't push to CAPZ collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,19 +89,6 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: capz-app-collection
-          context: "architect"
-          app_name: "kyverno-policy-operator"
-          app_collection_repo: "capz-app-collection"
-          requires:
-            - push-kyverno-policy-operator-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           name: gcp-app-collection
           context: "architect"
           app_name: "kyverno-policy-operator"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,19 +89,6 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: gcp-app-collection
-          context: "architect"
-          app_name: "kyverno-policy-operator"
-          app_collection_repo: "gcp-app-collection"
-          requires:
-            - push-kyverno-policy-operator-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           name: vsphere-app-collection
           context: "architect"
           app_name: "kyverno-policy-operator"


### PR DESCRIPTION
CAPZ uses default-apps to install the security-bundle, which causes conflicts with collection. We shouldn't push to collection anymore.