### PR TITLE
Remove app collections from circleci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,29 +87,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: vsphere-app-collection
-          context: "architect"
-          app_name: "kyverno-policy-operator"
-          app_collection_repo: "vsphere-app-collection"
-          requires:
-            - push-kyverno-policy-operator-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: cloud-director-app-collection
-          context: "architect"
-          app_name: "kyverno-policy-operator"
-          app_collection_repo: "cloud-director-app-collection"
-          requires:
-            - push-kyverno-policy-operator-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,16 +74,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          name: capa-app-collection
-          context: "architect"
-          app_name: "kyverno-policy-operator"
-          app_collection_repo: "capa-app-collection"
-          requires:
-            - push-kyverno-policy-operator-chart-to-control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
We remove kyverno-policy-operator from vsphere, cloud-director and capz collections. We consume it from security-bundle for MCs too.

See:
- https://github.com/giantswarm/vsphere-app-collection/pull/74/files
- https://github.com/giantswarm/capz-app-collection/pull/75/files
- https://github.com/giantswarm/cloud-director-app-collection/pull/75/files

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
