### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spec:
 This Policy Exception configuration will be detected by the Kyverno Policy Operator, which will create a corresponding Kyverno Policy Exception resource:
 
 ```yaml
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   labels:


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.