### PR TITLE
Fix chart-operator exception kinds argument

### DIFF
--- a/helm/kyverno-policy-operator/templates/deployment.yaml
+++ b/helm/kyverno-policy-operator/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           - --destination-namespace={{ .Values.policyOperator.destinationNamespace }}
         {{- end }}
         {{- if .Values.policyOperator.chartOperatorExceptionKinds }}
-          - --chart-operator-excempted-kinds={{ .Values.policyOperator.chartOperatorExceptionKinds | join "," }}
+          - --chart-operator-exception-kinds={{ .Values.policyOperator.chartOperatorExceptionKinds | join "," }}
         {{- end }}
           - --background-mode={{ .Values.policyOperator.exceptionBackgroundMode }}
         ports:


### PR DESCRIPTION
### Description

Fixes an issue where the manager can not start because of a wrong argument.