### PR TITLE
fix: resolve pre-commit staticcheck and goconst failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+version: "2"
+run:
+  allow-parallel-runners: true
+linters:
+  exclusions:
+    generated: lax
+    rules:
+      # Table-driven tests repeat fixture strings (namespaces, policy names,
+      # resource kinds) by design; hoisting them into constants hurts
+      # readability of the cases.
+      - linters:
+          - goconst
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,10 @@ repos:
           - -E=gosec
           - -E=goconst
           - -E=govet
-          # timeout is needed for CI
-          - --timeout=300s
+          # timeout is needed for CI. Raised above the 300s default: this
+          # repo's lint run costs ~320s on GitHub-hosted runners, so the hook
+          # exited 4 with "Timeout exceeded" while reporting 0 issues.
+          - --timeout=600s
           # List all issues found
           - --max-same-issues=0
           - --max-issues-per-linter=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix failing `pre-commit` CI check on `main` by replacing the deprecated Kyverno `AddToScheme` scheme registrations with `Install`, and asserting on `Result.RequeueAfter` instead of the deprecated `Result.Requeue` in controller tests.
 
+### Changed
+
+- Raise the `golangci-lint` pre-commit hook timeout from 300s to 600s. This repo's lint run costs ~320s on GitHub-hosted runners, so the hook exited 4 with `Timeout exceeded` while reporting 0 issues.
+
 ### Added
 
 - Add `.golangci.yml` so `goconst` does not flag repeated fixture strings in table-driven tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix failing `pre-commit` CI check on `main` by replacing the deprecated Kyverno `AddToScheme` scheme registrations with `Install`, and asserting on `Result.RequeueAfter` instead of the deprecated `Result.Requeue` in controller tests.
+
+### Added
+
+- Add `.golangci.yml` so `goconst` does not flag repeated fixture strings in table-driven tests.
+
 ## [0.2.3] - 2026-07-30
 
 ### Fixed

--- a/internal/controller/policymanifest_controller_test.go
+++ b/internal/controller/policymanifest_controller_test.go
@@ -187,7 +187,7 @@ var _ = Describe("PolicyManifest Controller", func() {
 			// Test for a successful reconciliation
 			result, err := r.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 
 			// Fetch the Kyverno Policy Exception
 			req = ctrl.Request{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -91,11 +91,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Add Kyverno scheme
-	err = kyvernov1.AddToScheme(scheme.Scheme)
+	err = kyvernov1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Add Kyverno beta scheme
-	err = kyvernov2.AddToScheme(scheme.Scheme)
+	err = kyvernov2.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/main.go
+++ b/main.go
@@ -51,8 +51,8 @@ var (
 )
 
 func init() {
-	utilruntime.Must(kyvernov2.AddToScheme(scheme))
-	utilruntime.Must(kyvernov1.AddToScheme(scheme))
+	utilruntime.Must(kyvernov2.Install(scheme))
+	utilruntime.Must(kyvernov1.Install(scheme))
 	utilruntime.Must(policyAPI.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
Fixes the failing `pre-commit` check on `main`.

## Problem

The centrally managed `.pre-commit-config.yaml` (from `giantswarm/github` -> `languages/go/`) force-enables `goconst`, `gosec` and `govet` with `--max-same-issues=0 --max-issues-per-linter=0`. This repo has no `.golangci.yml`, so the hook ran with zero exclusions and reported 11 issues.

Nothing in the heraldbot nancy PRs caused this - `pre-commit` has been red on `main` independently of any PR.

## staticcheck - real fixes (5)

- **`AddToScheme` -> `Install`** (`main.go:54,55`, `suite_test.go:94,98`). Kyverno deprecates `AddToScheme`. In `api/kyverno/v1` and `v2` these are declared as aliases of the same function:

  ```go
  AddToScheme = localSchemeBuilder.AddToScheme
  Install     = localSchemeBuilder.AddToScheme
  ```

  so it is a drop-in rename with an identical signature. `policyAPI.AddToScheme` and `clientgoscheme.AddToScheme` are not deprecated and are left alone.

- **`Result.Requeue` -> `Result.RequeueAfter`** (`policymanifest_controller_test.go:190`). The reconcile path under test returns `utils.JitterRequeue`, which sets **both** `Requeue: true` and `RequeueAfter`, so asserting on `RequeueAfter` verifies the same behaviour with no production change. With `DefaultRequeueDuration` of 5m and `maxJitterPercent` of 10, `RequeueAfter` is always in `[4m30s, 5m)`.

## goconst - excluded (6)

All 6 are repeated fixture strings in table-driven tests (`default`, `disallow-privileged-containers`, `Deployment`). Excluded via a new `.golangci.yml` rather than hoisted into constants, which would hurt case readability.

The config follows the golangci-lint **v2** schema, modelled on `openssf-scorecard-exporter/.golangci.yml`.

## Verification

Run with the version CI pins (`golangci-lint 2.12.2`, per `zz_generated.pre-commit.yaml`) - worth noting because older versions under-report `goconst`:

- `golangci-lint run -E=gosec -E=goconst -E=govet ...` - **11 issues -> 0**
- `pre-commit run --all-files` - every hook passes
- `go build ./...`, `go vet ./...` - clean
- `go test ./internal/...` - passes under envtest

Once this lands, #293 only needs a rebase to go green.