### PR TITLE
docs: point kagent reference at the renamed repo

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -10,8 +10,8 @@ upgrade-tests-cluster-type: kind
 # the deploy. The smoke test under tests/ats is ready and written against the
 # next ATS release's contract (`cluster-crds` option + ATS_RELEASE_* env
 # vars, both in ATS's unreleased changelog). Same approach as
-# giantswarm/kagent-app.
+# giantswarm/kagent.
 # @TODO: once dats.sh ships ATS > 0.15.0, remove `smoke` from skip-steps and
 # add:
-#   cluster-crds: https://raw.githubusercontent.com/giantswarm/kagent-app/v0.1.25/helm/kagent/crds/kagent.dev/kagent.dev_agents.yaml
+#   cluster-crds: https://raw.githubusercontent.com/giantswarm/kagent/v0.1.25/helm/kagent/crds/kagent.dev/kagent.dev_agents.yaml
 skip-steps: [smoke,functional,upgrade]


### PR DESCRIPTION
## Problem

`giantswarm/kagent-app` was renamed to `giantswarm/kagent` (giantswarm/giantswarm#37432). The `.ats/main.yaml` comment names the old repo, including the `cluster-crds` URL a future reader is meant to paste in once ATS > 0.15.0 ships.

## Change

Comment only. No test configuration changes.